### PR TITLE
Generalize ContextMenu handling.

### DIFF
--- a/src/renderer/actions/ContextMenuActions.js
+++ b/src/renderer/actions/ContextMenuActions.js
@@ -1,0 +1,22 @@
+"use babel";
+
+var AppDispatcher = require('../dispatcher/AppDispatcher')
+var ContextMenuConstants = require('../constants/ContextMenuConstants')
+
+var ContextMenuActions = {
+  show: function(actions, position, event){
+    AppDispatcher.dispatch({
+      actionType: ContextMenuConstants.CONTEXT_MENU_SHOW,
+      actions: actions,
+      position: position,
+      event: event
+    })
+  },
+  hide: function(){
+    AppDispatcher.dispatch({
+      actionType: ContextMenuConstants.CONTEXT_MENU_HIDE
+    })
+  }
+}
+
+module.exports = ContextMenuActions

--- a/src/renderer/components/ContextMenu.jsx
+++ b/src/renderer/components/ContextMenu.jsx
@@ -6,15 +6,22 @@ var cx = require('classnames')
 
 var ContextMenu = React.createClass({
   propTypes: {
-    actions: ReactPropTypes.array.isRequired
+    actions: ReactPropTypes.array.isRequired,
+    position: ReactPropTypes.object.isRequired,
+    isVisible: ReactPropTypes.bool.isRequired
   },
   render: function() {
     var classes = cx({
       'context-menu'  : true,
-      'list-unstyled' : true
+      'list-unstyled' : true,
+      'visible'       : this.props.isVisible
     })
+    var style = {
+      top: this.props.position.top,
+      left: this.props.position.left
+    }
     return (
-      <ul className={classes}>
+      <ul className={classes} style={style}>
         {this.props.actions.map( action => <li key={action.label}><a href="#" onClick={action.handler}>{action.label}</a></li> )}
       </ul>
     )

--- a/src/renderer/components/playlist/AlbumPlaylist.jsx
+++ b/src/renderer/components/playlist/AlbumPlaylist.jsx
@@ -30,7 +30,7 @@ var AlbumPlaylist = React.createClass({
   },
   getInitialState: function(){
     return _.extend({
-      openMenu: null
+
     }, getPlayerState())
   },
   componentDidMount: function(){
@@ -52,7 +52,6 @@ var AlbumPlaylist = React.createClass({
           closeElements={this.props.closeElements}
           focusParent={this.props.focusParent}
           handleClick={this.handleClick}
-          handleMenuLinkClick={this.handleMenuLinkClick}
           handleFolderDrop={this.handleFolderDrop}
           handleDragEnd={this.handleDragEnd}
           playTrack={this.playTrack}
@@ -61,8 +60,7 @@ var AlbumPlaylist = React.createClass({
           direction={this.props.direction}
           isOpened={isOpened}
           isSelected={isSelected}
-          isKeyFocused={isOpened && isSelected && (this.props.selection.length == 1)}
-          isMenuOpened={this.state.openMenu == album.id}/>
+          isKeyFocused={isOpened && isSelected && (this.props.selection.length == 1)}/>
       )
     })
 
@@ -81,11 +79,6 @@ var AlbumPlaylist = React.createClass({
   },
   handleClick: function(event, item){
     this.props.handleClick(event, item)
-  },
-  handleMenuLinkClick: function(event, item){
-    this.setState({
-      openMenu: item.props.itemKey
-    })
   },
   handleFolderDrop: function(folder, afterId){
     if(!afterId){

--- a/src/renderer/components/playlist/AlbumPlaylistItem.jsx
+++ b/src/renderer/components/playlist/AlbumPlaylistItem.jsx
@@ -13,9 +13,8 @@ require("moment-duration-format")
 
 var DragDropConstants = require('../../constants/DragDropConstants')
 var AlbumTracklistItem = require('./AlbumTracklistItem.jsx')
-var ContextMenu = require('./ContextMenu.jsx')
-
 var KeyboardFocusActions = require('../../actions/KeyboardFocusActions')
+var ContextMenuActions = require('../../actions/ContextMenuActions')
 
 const albumSource = {
   beginDrag(props) {
@@ -100,41 +99,6 @@ var AlbumPlaylistItem = React.createClass({
       <ol className="list-unstyled tracklist">{ renderedTracklist }</ol>
     )
   },
-  renderContextMenu: function(){
-    var actions = [
-      {
-        'label': 'Reveal in Finder',
-        'handler': function(event){
-          event.stopPropagation()
-          shell.openExternal('file://' + this.props.album.getFolder())
-        }.bind(this)
-      },
-      {
-        'label': 'Search on Discogs',
-        'handler': function(event){
-          event.stopPropagation()
-          this.openLink('http://www.discogs.com/search?type=release&q=')
-        }.bind(this)
-      },
-      {
-        'label': 'Search on RYM',
-        'handler': function(event){
-          event.stopPropagation()
-          this.openLink('https://rateyourmusic.com/search?searchtype=l&searchterm=')
-        }.bind(this)
-      },
-      {
-        'label': 'Search on Last.fm',
-        'handler': function(event){
-          event.stopPropagation()
-          this.openLink('http://www.last.fm/search?type=album&q=')
-        }.bind(this)
-      }
-    ]
-    return (
-      <ContextMenu actions={actions}/>
-    )
-  },
   render: function() {
     var isPlaying = this.props.album.contains(this.props.currentItem.id)
     var classes = cx({
@@ -151,14 +115,13 @@ var AlbumPlaylistItem = React.createClass({
       'menuOpened'  : !!this.props.isMenuOpened
     })
     return this.props.connectDragSource(this.props.connectDropTarget(
-      <li className={classes} onClick={this.handleClick} onDoubleClick={this.handleDoubleClick} data-id={this.props.album.id} style={{opacity}}>
+      <li className={classes} onClick={this.handleClick} onDoubleClick={this.handleDoubleClick} onContextMenu={this.handleMenuLinkClick} data-id={this.props.album.id} style={{opacity}}>
         <header>
           <div className={coverClasses} style={coverStyle}></div>
           <span className="artist">{this.props.album.getArtist()}</span><br/>
           <span className="title">{this.props.album.getTitle()} { (isPlaying && !this.props.isOpened) ? <i className="fa fa-fw fa-volume-up"></i> : null }</span>
           <a href="#" className="menu-link" onClick={this.handleMenuLinkClick}><i className="fa fa-fw fa-ellipsis-h"></i></a>
           <span className="year">{this.props.album.getYear()}</span>
-          { this.props.isMenuOpened ? this.renderContextMenu() : null }
         </header>
         { this.props.isOpened ? this.renderTracklist() : null }
       </li>
@@ -166,7 +129,7 @@ var AlbumPlaylistItem = React.createClass({
   },
   handleMenuLinkClick: function(event){
     event.stopPropagation()
-    this.props.handleMenuLinkClick(event, this)
+    ContextMenuActions.show(this.getContextMenuActions(), { top: event.clientY, left: event.clientX }, event)
   },
   handleTracklistDoubleClick: function(event, item){
     event.stopPropagation()
@@ -231,7 +194,42 @@ var AlbumPlaylistItem = React.createClass({
       'up, down, left'  : this.handleArrowKeyPress,
       'enter'           : this.handleEnterKeyPress
     }
-  }
+  },
+  getContextMenuActions: function(){
+    return [
+      {
+        'label': 'Reveal in Finder',
+        'handler': function(event){
+          event.stopPropagation()
+          shell.openExternal('file://' + this.props.album.getFolder())
+        }.bind(this)
+      },
+      {
+        'label': 'Search on Discogs',
+        'handler': function(event){
+          event.stopPropagation()
+          this.openLink('http://www.discogs.com/search?type=release&q=')
+        }.bind(this)
+      },
+      {
+        'label': 'Search on RYM',
+        'handler': function(event){
+          event.stopPropagation()
+          this.openLink('https://rateyourmusic.com/search?searchtype=l&searchterm=')
+        }.bind(this)
+      },
+      {
+        'label': 'Search on Last.fm',
+        'handler': function(event){
+          event.stopPropagation()
+          this.openLink('http://www.last.fm/search?type=album&q=')
+        }.bind(this)
+      }
+    ]
+  },
+  openLink: function(base){
+    shell.openExternal(base + encodeURIComponent(this.props.album.getArtist() + ' ' + this.props.album.getTitle()))
+  }  
 })
 
 AlbumPlaylistItem = DropTarget([

--- a/src/renderer/components/sidebar/FileBrowserTab.jsx
+++ b/src/renderer/components/sidebar/FileBrowserTab.jsx
@@ -2,6 +2,7 @@
 
 var _ = require('lodash')
 var cx = require('classnames')
+var shell = require('shell')
 var React = require('react')
 var ReactPropTypes = React.PropTypes
 var FileBrowser = require('./FileBrowser.jsx')
@@ -11,6 +12,8 @@ var NavGenerator = require('../../generators/Navigable.jsx')
 
 var KeyboardFocusActions = require('../../actions/KeyboardFocusActions')
 var KeyboardNameSpaceConstants = require('../../constants/KeyboardNameSpaceConstants')
+var ContextMenuActions = require('../../actions/ContextMenuActions')
+var OpenPlaylistActions = require('../../actions/OpenPlaylistActions')
 
 var FileBrowserOnSteroids = NavGenerator(FileBrowser, KeyboardNameSpaceConstants.FILE_BROWSER,
   function(component){
@@ -61,6 +64,7 @@ var FileBrowserTab = React.createClass({
           handleContextMenu={this.handleContextMenu}
           handleOpen={this.handleOpen}
           handleClose={this.handleClose}
+          handleContextMenu={this.handleContextMenu}
           isFocused={this.props.isFocused}
           tree={this.state.fileTree}/>
       </div>
@@ -86,7 +90,7 @@ var FileBrowserTab = React.createClass({
     }
   },
   handleContextMenu: function(event, item){
-
+    ContextMenuActions.show(this.getContextMenuActions(item), { top: event.clientY, left: event.clientX }, event)
   },
   handleOpen: function(ids){
     FileBrowserActions.expandNodes(this.state.fileTree.filter((node)=>{
@@ -102,6 +106,24 @@ var FileBrowserTab = React.createClass({
     this.setState({
       fileTree: FileBrowserStore.getFileTree()
     })
+  },
+  getContextMenuActions: function(item){
+    return [
+      {
+        'label'   : 'Reveal in Finder',
+        'handler' : function(event){
+          event.stopPropagation()
+          shell.openExternal('file://' + item.props.node.path)
+        }.bind(this)
+      },
+      {
+        'label'   : 'Add ' + item.props.node.name + ' to current playlist',
+        'handler' : function(event){
+          event.stopPropagation()
+          OpenPlaylistActions.addFolder(item.props.node.path)
+        }.bind(this)
+      }
+    ]
   }
 })
 

--- a/src/renderer/components/sidebar/PlaylistBrowserTab.jsx
+++ b/src/renderer/components/sidebar/PlaylistBrowserTab.jsx
@@ -14,6 +14,8 @@ var AlbumPlaylist = require('../../util/AlbumPlaylist')
 
 var KeyboardFocusActions = require('../../actions/KeyboardFocusActions')
 var KeyboardNameSpaceConstants = require('../../constants/KeyboardNameSpaceConstants')
+var ContextMenuActions = require('../../actions/ContextMenuActions')
+var OpenPlaylistActions = require('../../actions/OpenPlaylistActions')
 
 var FileBrowserOnSteroids = NavGenerator(FileBrowser, KeyboardNameSpaceConstants.PLAYLIST_BROWSER,
   function(component){
@@ -46,6 +48,7 @@ var PlaylistBrowserTab = React.createClass({
           handleScrollToElement={this.handleScrollToElement}
           handleDoubleClick={this.handleDoubleClick}
           handleArrowClick={this.handleArrowClick}
+          handleContextMenu={this.handleContextMenu}
           handleOpen={this.handleOpen}
           handleClose={this.handleClose}
           isFocused={this.props.isFocused}
@@ -78,6 +81,9 @@ var PlaylistBrowserTab = React.createClass({
       PlaylistBrowserActions.collapseNodes([item.props.node])
     }
   },
+  handleContextMenu: function(event, item){
+    ContextMenuActions.show(this.getContextMenuActions(item), { top: event.clientY, left: event.clientX }, event)
+  },
   handleOpen: function(ids){
     var nodes = this._getNodesById(ids)
     nodes.length && PlaylistBrowserActions.expandNodes(nodes)
@@ -100,6 +106,17 @@ var PlaylistBrowserTab = React.createClass({
     return this.state.playlistTree.filter((node)=>{
       return _.contains(ids, node.id) && node.isDirectory()
     })
+  },
+  getContextMenuActions: function(item){
+    return [
+      {
+        'label'   : 'Load playlist',
+        'handler' : function(event){
+          event.stopPropagation()
+          this._openPlaylist(item.props.node.path)
+        }.bind(this)
+      }
+    ]
   }
 })
 

--- a/src/renderer/constants/ContextMenuConstants.js
+++ b/src/renderer/constants/ContextMenuConstants.js
@@ -1,0 +1,6 @@
+var keyMirror = require('keymirror')
+
+module.exports = keyMirror({
+  CONTEXT_MENU_SHOW: null,
+  CONTEXT_MENU_HIDE: null
+})

--- a/src/renderer/stores/ContextMenuStore.js
+++ b/src/renderer/stores/ContextMenuStore.js
@@ -1,0 +1,63 @@
+"use babel";
+
+var assign = require('object-assign')
+var ipc = require('ipc')
+
+var AppDispatcher = require('../dispatcher/AppDispatcher')
+var EventEmitter = require('events').EventEmitter
+var ContextMenuConstants = require('../constants/ContextMenuConstants')
+
+var CHANGE_EVENT = 'change'
+
+var _isVisible = false
+var _actions = []
+var _position = {}
+
+var ContextMenuStore = assign({}, EventEmitter.prototype, {
+  getInfo: function(){
+    return {
+      isVisible: _isVisible,
+      actions: _actions,
+      position: _position
+    }
+  },
+
+  emitChange: function() {
+    this.emit(CHANGE_EVENT)
+  },
+
+  /**
+   * @param {function} callback
+   */
+  addChangeListener: function(callback) {
+    this.on(CHANGE_EVENT, callback)
+  },
+
+  /**
+   * @param {function} callback
+   */
+  removeChangeListener: function(callback) {
+    this.removeListener(CHANGE_EVENT, callback)
+  },
+
+  dispatcherIndex: AppDispatcher.register(function(action) {
+    switch(action.actionType) {
+      case ContextMenuConstants.CONTEXT_MENU_SHOW:
+        _actions = action.actions
+        _position = action.position
+        _isVisible = true
+        ContextMenuStore.emitChange()
+        break
+      case ContextMenuConstants.CONTEXT_MENU_HIDE:
+        _actions = []
+        _isVisible = false
+        ContextMenuStore.emitChange()
+        break
+    }
+
+    return true // No errors. Needed by promise in Dispatcher.
+  })
+
+})
+
+module.exports = ContextMenuStore

--- a/src/styles/_context_menu.styl
+++ b/src/styles/_context_menu.styl
@@ -1,8 +1,7 @@
 .context-menu
   position absolute
-  top 3.5rem
-  right 4rem
-  width size($albumContextMenuWidth)
+  min-width size($albumContextMenuMinWidth)
+  max-width size($albumContextMenuMaxWidth)
   background-color $albumContextMenuBgColor
   border-radius .5rem
   line-height 2rem
@@ -11,11 +10,20 @@
   z-index 1050
   margin 0
   padding 0
+  display none
+  &.visible
+    display block
   li
     vertical-align middle
     box-shadow inset 0 -1px rgba($mainColor, .1)
+    ellipsed()
+    &:first-child
+      border-top-left-radius .5rem
+      border-top-right-radius .5rem
     &:last-child
       box-shadow none
+      border-bottom-left-radius .5rem
+      border-bottom-right-radius .5rem
     a
       display block
       padding 0 1rem

--- a/src/styles/_variables.styl
+++ b/src/styles/_variables.styl
@@ -60,7 +60,8 @@ $dropAreaTextColor = rgba(white, .25)
 $dropAreaFontSize = 2 * $baseFontSize
 
 // Context menu
-$albumContextMenuWidth = 10 * $baseFontSize
+$albumContextMenuMinWidth = 10 * $baseFontSize
+$albumContextMenuMaxWidth = 15 * $baseFontSize
 $albumContextMenuBgColor = rgba(black, .9)
 
 // Sidebar


### PR DESCRIPTION
Is it now possible to open a `ContextMenu` via following action:

```
ContextMenuActions.show(actions, position, event)
```

Where `actions` is an array of label/handler hashes like:

```
[
  {
    'label': 'Reveal in Finder',
    'handler': function(event){
      event.stopPropagation()
      shell.openExternal('file://' + this.props.album.getFolder())
    }.bind(this)
  },
  {
    'label': 'Search on Discogs',
    'handler': function(event){
      event.stopPropagation()
      ...
    }.bind(this)
  },
  ...
]
```

then `position` is a `{ top: _value, left: _value}` pair, and `event` is the original `SyntheticEvent` passed to the handler.

`ContextMenu`gets hidden when clicking anywhere in the browser window.
